### PR TITLE
Remove SSH tunneling & reconect with public access to RDS

### DIFF
--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -1,19 +1,23 @@
 import { createResponse, handleError } from "@/src/helper/apiUtils";
-import { executeQuery } from "@/src/lib/mysqlClient.server";
-import { NextRequest, NextResponse } from "next/server";
+import { executeQueries, executeQuery } from "@/src/lib/mysqlClient.server";
+import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
   try {
+    console.log("executeQuery called");
     const type: string | null = req.nextUrl.searchParams.get("type");
     const sql =
       "SELECT * FROM Category where category_type = ? ORDER BY category_id ASC";
+    const testSql = [{ sql: sql, values: [type] }];
     if (!type) {
       throw new Error("category type is required");
     }
-    const result = await executeQuery(sql, [type]);
+    const result = await executeQueries(testSql);
     return createResponse(req, result, 200);
-    return NextResponse.json(result, { status: 200 });
   } catch (err) {
+    console.error("--------------------------------------------------");
+    console.error("error from api");
+    console.error("--------------------------------------------------");
     return handleError(err);
   }
 }
@@ -26,7 +30,6 @@ export async function POST(req: NextRequest) {
       "INSERT INTO Category (category_name, category_type) VALUES (?,?)";
     const result = await executeQuery(sql, values);
     return createResponse(req, result, 200);
-    return NextResponse.json(result, { status: 200 });
   } catch (err) {
     return handleError(err);
   }

--- a/src/app/api/post/category/[id]/route.ts
+++ b/src/app/api/post/category/[id]/route.ts
@@ -5,7 +5,6 @@ import {
 } from "@/src/helper/apiUtils";
 import { postCardFormatting } from "@/src/helper/postHelper";
 import {
-  createConnection,
   QueryConfig,
   executeQueries,
   CustomRowDataPacket,
@@ -18,9 +17,7 @@ interface Props {
 }
 
 export async function GET(req: NextRequest, { params }: { params: Props }) {
-  const connection = await createConnection();
   try {
-    await connection.beginTransaction();
     /**
      * ⭐️ step 1: get common params ⭐️
      */
@@ -77,7 +74,7 @@ export async function GET(req: NextRequest, { params }: { params: Props }) {
      * ⭐️ step 3: execute queries ⭐️
      */
     const [mainResult, mainCountResult] =
-      await executeQueries<CustomRowDataPacket>(connection, queries);
+      await executeQueries<CustomRowDataPacket>(queries);
     const mainPosts: IMainPostCard[] = (mainResult as any[])[0];
     const ids: string[] = mainPosts.map((e) => e.post_id);
     if (ids.length === 0) {
@@ -96,10 +93,7 @@ export async function GET(req: NextRequest, { params }: { params: Props }) {
         values: ids,
       },
     ];
-    const [subResult] = await executeQueries<CustomRowDataPacket>(
-      connection,
-      queries
-    );
+    const [subResult] = await executeQueries<CustomRowDataPacket>(queries);
     /**
      * ⭐️ step 4: process data ⭐️
      */
@@ -118,6 +112,5 @@ export async function GET(req: NextRequest, { params }: { params: Props }) {
     console.log(err);
     return handleError(err);
   } finally {
-    await connection.end();
   }
 }

--- a/src/app/api/post/search/route.ts
+++ b/src/app/api/post/search/route.ts
@@ -5,7 +5,6 @@ import {
 } from "@/src/helper/apiUtils";
 import { postCardFormatting } from "@/src/helper/postHelper";
 import {
-  createConnection,
   CustomRowDataPacket,
   executeQueries,
   QueryConfig,
@@ -14,9 +13,7 @@ import { IMainPostCard, ISubPostCard } from "@/type";
 import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const connection = await createConnection();
   try {
-    await connection.beginTransaction();
     /**
      * ⭐️ step 1: get common params ⭐️
      */
@@ -55,7 +52,7 @@ export async function GET(req: NextRequest) {
      * ⭐️ step 3: execute queries to get subPostCard Data based on searched title⭐️
      */
     const [subResult, subCountResult] =
-      await executeQueries<CustomRowDataPacket>(connection, queries);
+      await executeQueries<CustomRowDataPacket>(queries);
     const totalCount = subCountResult[0][0]?.totalCount;
     const user_id: string | null = req.headers.get("user-id");
     if (user_id !== "1") {
@@ -94,10 +91,7 @@ export async function GET(req: NextRequest) {
     /**
      * ⭐️ step 6: construct queries to get main post card based on result of the subPostCard ⭐️
      */
-    const [mainResult] = await executeQueries<CustomRowDataPacket>(
-      connection,
-      queries
-    );
+    const [mainResult] = await executeQueries<CustomRowDataPacket>(queries);
     const mainPosts: IMainPostCard[] = (mainResult as any[])[0].sort(
       (a: IMainPostCard, b: IMainPostCard) =>
         parseInt(b.post_id) - parseInt(a.post_id)
@@ -117,6 +111,5 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     return handleError(err);
   } finally {
-    await connection.end();
   }
 }

--- a/src/app/api/related/route.ts
+++ b/src/app/api/related/route.ts
@@ -1,7 +1,6 @@
 import { createResponse, handleError } from "@/src/helper/apiUtils";
 import { executeQuery } from "@/src/lib/mysqlClient.server";
-import { RelatedPost } from "@/type";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
   try {
@@ -17,11 +16,8 @@ export async function GET(req: NextRequest) {
         "SELECT post_id, title, created_at, comments, type FROM Post WHERE category_id = (SELECT category_id FROM Post WHERE post_id = ?) AND post_id < ? ORDER BY post_id ASC LIMIT 3";
       const result = await executeQuery(sql, [post_id, post_id]);
       return createResponse(req, result, 200);
-      return NextResponse.json(result, { status: 200 });
     } else {
       return createResponse(req, result, 200);
-
-      return NextResponse.json(result, { status: 200 });
     }
   } catch (err) {
     return handleError(err);

--- a/src/components/sidebar/CategoryList.tsx
+++ b/src/components/sidebar/CategoryList.tsx
@@ -12,6 +12,7 @@ const CategoryList = async ({ from }: { from: string }) => {
       next: { tags: [`category-${from}`] },
     }
   );
+
   const result = await response.json();
   return (
     <SidebarMenu>

--- a/src/lib/mysqlClient.server.ts
+++ b/src/lib/mysqlClient.server.ts
@@ -1,11 +1,142 @@
+// import mysql, {
+//   FieldPacket,
+//   ResultSetHeader,
+//   RowDataPacket,
+// } from "mysql2/promise";
+// import { Client } from "ssh2";
+// import { Pool } from "mysql2/promise";
+// export type QueryConfig = {
+//   sql: string;
+//   values: any[];
+// };
+// export type QueryResult<T> = [T[], FieldPacket[]];
+// export interface CustomRowDataPacket extends RowDataPacket {
+//   totalCount?: number;
+// }
+
+// let pool: Pool | null = null;
+
+// export const createPoolOverSSH = async (): Promise<Pool> => {
+//   if (pool) return pool;
+//   const privateKeyBase64 = process.env.SSH_PRIVATE_KEY_B64!;
+//   const privateKeyBuffer = Buffer.from(privateKeyBase64, "base64");
+//   const sshConfig = {
+//     host: process.env.SSH_HOST!,
+//     port: parseInt(process.env.SSH_PORT || "22"),
+//     username: process.env.SSH_USERNAME!,
+//     privateKey: privateKeyBuffer,
+//   };
+//   const forwardConfig = {
+//     srcHost: "127.0.0.1",
+//     srcPort: 0,
+//     dstHost: process.env.DB_HOST!,
+//     dstPort: parseInt(process.env.DB_PORT || "3306"),
+//   };
+//   const ssh = new Client();
+//   return new Promise<Pool>((resolve, reject) => {
+//     ssh.on("ready", () => {
+//       ssh.forwardOut(
+//         forwardConfig.srcHost,
+//         forwardConfig.srcPort,
+//         forwardConfig.dstHost,
+//         forwardConfig.dstPort,
+//         (err, stream) => {
+//           if (err) {
+//             ssh.end();
+//             return reject(err);
+//           }
+//           // SSH 스트림으로 MySQL Pool 생성
+//           pool = mysql.createPool({
+//             host: "127.0.0.1",
+//             user: process.env.DB_USER!,
+//             password: process.env.DB_PASSWORD!,
+//             database: process.env.DB_NAME!,
+//             stream,
+//             waitForConnections: true,
+//             connectionLimit: 30,
+//             queueLimit: 100,
+//             idleTimeout: 60000,
+//           });
+//           resolve(pool);
+//         }
+//       );
+//     });
+//     ssh.on("error", (err) => {
+//       reject(err);
+//     });
+//     ssh.connect(sshConfig);
+//   });
+// };
+
+// async function getConnectionWithRetry(
+//   pool: Pool,
+//   retries = 3
+// ): Promise<mysql.PoolConnection> {
+//   console.error("here");
+//   for (let i = 0; i < retries; i++) {
+//     try {
+//       const conn = await pool.getConnection();
+//       return conn;
+//     } catch (err: any) {
+//       // 재시도 가능한 에러인지 확인
+//       if (
+//         err.code === "PROTOCOL_CONNECTION_LOST" ||
+//         err.code === "ECONNRESET" ||
+//         err.code === "ECONNREFUSED"
+//       ) {
+//         console.warn(`Connection lost, retrying... (${i + 1}/${retries})`);
+//         await new Promise((res) => setTimeout(res, 500)); // 잠시 대기 후 재시도
+//         continue;
+//       }
+//       throw err;
+//     }
+//   }
+//   throw new Error("Failed to get DB connection after retries");
+// }
+
+// export async function executeQuery(
+//   sql: string,
+//   values?: (string | number)[]
+// ): Promise<ResultSetHeader> {
+//   const pool = await createPoolOverSSH();
+//   const conn = await getConnectionWithRetry(pool);
+//   try {
+//     const [result] = await conn.query(sql, values || []);
+//     return result as ResultSetHeader;
+//   } finally {
+//     conn.release();
+//   }
+// }
+
+// export async function executeQueries<T extends RowDataPacket>(
+//   queries: QueryConfig[]
+// ): Promise<QueryResult<T>[]> {
+//   const pool = await createPoolOverSSH(); // SSH + pool 연결 (네가 정의한 함수)
+//   const conn = await getConnectionWithRetry(pool);
+//   try {
+//     await conn.beginTransaction();
+//     // 쿼리들을 순차적으로 실행
+//     const results: QueryResult<T>[] = [];
+//     for (const { sql, values } of queries) {
+//       const result = await conn.query<T[]>(sql, values);
+//       results.push(result);
+//     }
+//     await conn.commit();
+//     return results;
+//   } catch (err) {
+//     await conn.rollback(); // 실패 시 전체 롤백
+//     throw err;
+//   } finally {
+//     conn.release(); // 커넥션 반환 (풀로)
+//   }
+// }
+
 import mysql, {
   Connection,
   FieldPacket,
   ResultSetHeader,
   RowDataPacket,
 } from "mysql2/promise";
-import fs from "fs";
-import { Client } from "ssh2";
 
 export type QueryConfig = {
   sql: string;
@@ -14,74 +145,21 @@ export type QueryConfig = {
 
 export type QueryResult<T> = [T[], FieldPacket[]];
 
-export interface CustomRowDataPacket extends RowDataPacket {
-  totalCount?: number;
+export declare interface CustomRowDataPacket extends RowDataPacket {
+  totalCount?: number; // 추가 필드
 }
 
-let connection: Connection | null = null;
-
-export const createConnection = async (): Promise<Connection> => {
-  if (connection) return connection;
-
-  // SSH 설정
-
-  const privateKeyBase64 = process.env.SSH_PRIVATE_KEY_B64;
-
-  if (!privateKeyBase64) {
-    throw new Error("SSH key Error");
-  }
-
-  const privateKeyBuffer = Buffer.from(privateKeyBase64, "base64");
-
-  const sshConfig = {
-    host: process.env.SSH_HOST!,
-    port: parseInt(process.env.SSH_PORT || "22"),
-    username: process.env.SSH_USERNAME!,
-    privateKey: privateKeyBuffer,
-  };
-
-  // MySQL 설정
-  const dbConfig = {
-    host: "127.0.0.1", // SSH 터널을 통해 로컬로 접속
-    port: 3307, // 아래에서 할당받는 포트와 일치해야 함
-    user: process.env.DB_USER!,
-    password: process.env.DB_PASSWORD!,
-    database: process.env.DB_NAME!,
+export const createConnection = async () => {
+  const connection: Connection = await mysql.createConnection({
+    host: process.env.DB_HOST_DIR,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
     waitForConnections: true,
-    connectionLimit: 10,
+    connectionLimit: 10, // 동시에 최대 10개의 연결 유지
     queueLimit: 0,
-  };
-
-  // SSH 터널링
-  return new Promise<Connection>((resolve, reject) => {
-    const ssh = new Client();
-    ssh.on("ready", () => {
-      ssh.forwardOut(
-        "127.0.0.1",
-        0,
-        process.env.DB_HOST!,
-        parseInt(process.env.DB_PORT || "3306"),
-        async (err, stream) => {
-          if (err) {
-            ssh.end();
-            return reject(err);
-          }
-          try {
-            const conn = await mysql.createConnection({
-              ...dbConfig,
-              stream,
-            });
-            connection = conn;
-            resolve(conn);
-          } catch (dbErr) {
-            reject(dbErr);
-          }
-        }
-      );
-    });
-    ssh.on("error", reject);
-    ssh.connect(sshConfig);
   });
+  return connection;
 };
 
 export async function executeQuery(sql: string, values?: (string | number)[]) {
@@ -89,17 +167,31 @@ export async function executeQuery(sql: string, values?: (string | number)[]) {
   try {
     const [result] = await db.query(sql, values || []);
     return result as ResultSetHeader;
-  } catch (err) {
-    connection = null;
-    throw err;
+  } finally {
+    await db.end();
   }
 }
 
 export async function executeQueries<T extends RowDataPacket>(
-  connection: Connection,
   queries: QueryConfig[]
 ): Promise<QueryResult<T>[]> {
-  return Promise.all(
-    queries.map(({ sql, values }) => connection.query<T[]>(sql, values))
-  );
+  const connection = await createConnection();
+
+  try {
+    await connection.beginTransaction();
+
+    const results: QueryResult<T>[] = [];
+    for (const { sql, values } of queries) {
+      const result = await connection.query<T[]>(sql, values);
+      results.push(result);
+    }
+
+    await connection.commit();
+    return results;
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    await connection.end();
+  }
 }


### PR DESCRIPTION
기존에는 SSH 터널링을 통해 EC2를 경유해 RDS에 접속했으나, 다음과 같은 이유로 구조를 단순화하고 **직접 RDS에 연결하는 방식**으로 변경했습니다.

### ✨ 주요 변경 사항
- `createPoolOverSSH()` → `createConnection()`로 변경하여 직접 연결
- `.env` 환경변수에서 SSH 관련 설정 변경 DB_HOST_SSH, DB_HOST_DIR 추가
- 연결 방식 단순화로 인해 불안정한 스트림/커넥션 오류(`connection is in closed state`) 방지

### 🔧 배경 및 이유
- SSH 스트림은 다중 커넥션 풀 구조에서 불안정한 동작을 보임
- 반복적인 `"Can't add new command when connection is in closed state"` 오류 발생
- RDS에서 IPv4 퍼블릭 접근이 가능해짐에 따라 SSH 터널링이 불필요해짐
